### PR TITLE
検索範囲の指定機能の実装

### DIFF
--- a/lib/home/home_screen.dart
+++ b/lib/home/home_screen.dart
@@ -145,7 +145,7 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  Future<void> _performSearch(String query) async {
+  Future<void> _performSearch(String query, String selectedRadius) async {
     setState(() => _searchResults = []); // 検索中は結果をクリア
 
     // 検索タイプを判断（駅名かエリア名か）
@@ -160,13 +160,14 @@ class _HomeScreenState extends State<HomeScreen> {
       }
     }
 
-    // 検索実行時に選択されたチェーン店の情報を渡す
+    // 検索実行時に選択されたチェーン店の情報と距離を渡す
     final results = await PlacesService().searchKaraoke(
       query,
       userLocation: _userLocation,
       searchLocation: searchLocation,
       isStation: isStation,
-      selectedChains: _selectedChains, // 選択されたチェーン店を追加
+      selectedChains: _selectedChains,
+      radius: int.parse(selectedRadius),
     );
 
     // マーカーを更新
@@ -259,11 +260,10 @@ class _HomeScreenState extends State<HomeScreen> {
               selectedChains: _selectedChains,
               onChainsUpdated: (newChains) async {
                 await _saveSelectedChains(newChains);
-
                 // 強制的に現在の検索を再実行
                 final currentQuery = _searchController.text;
                 if (currentQuery.isNotEmpty) {
-                  await _performSearch(currentQuery);
+                  await _performSearch(currentQuery, '500');
                 }
               },
             ),

--- a/lib/home/screens/search_detail_screen.dart
+++ b/lib/home/screens/search_detail_screen.dart
@@ -90,6 +90,7 @@ class _SearchDetailScreenState extends State<SearchDetailScreen> {
     _searchController.text = text;
     final searchType = text.contains('駅') ? 'station' : 'location';
     await _saveSearchHistory(text, searchType);
+    if (!mounted) return;
     Navigator.pop(context, text);
   }
 
@@ -121,10 +122,11 @@ class _SearchDetailScreenState extends State<SearchDetailScreen> {
           onChanged: _onSearchChanged,
           onSubmitted: (value) async {
             if (value.isNotEmpty) {
-              final navigator = Navigator.of(context);
               if (!mounted) return;
+              final navigator = Navigator.of(context);
               final searchType = value.contains('駅') ? 'station' : 'location';
               await _saveSearchHistory(value, searchType);
+              if (!mounted) return;
               navigator.pop(value);
             }
           },
@@ -207,6 +209,7 @@ class _SearchDetailScreenState extends State<SearchDetailScreen> {
                             ),
                             onTap: () {
                               final navigator = Navigator.of(context);
+                              if (!mounted) return;
                               navigator.pop(history.searchQuery);
                             },
                           ),

--- a/lib/home/widgets/search_header_widget.dart
+++ b/lib/home/widgets/search_header_widget.dart
@@ -6,7 +6,7 @@ import '../../app_state.dart';
 
 class SearchHeaderWidget extends StatefulWidget {
   final TextEditingController? searchController;
-  final Function(String)? onSearch;
+  final Function(String, String)? onSearch;
   final Map<String, bool> selectedChains;
   final Function(Map<String, bool>) onChainsUpdated;
 
@@ -91,7 +91,7 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                         setState(() {
                           _searchController.text = result;
                         });
-                        widget.onSearch?.call(result);
+                        widget.onSearch?.call(result, _selectedRadius);
                       }
                     },
                     decoration: InputDecoration(
@@ -103,6 +103,11 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                       filled: true,
                       fillColor: Colors.grey[200],
                     ),
+                    onSubmitted: (value) {
+                      if (value.isNotEmpty) {
+                        widget.onSearch?.call(value, _selectedRadius);
+                      }
+                    },
                   ),
                 ),
                 const SizedBox(width: 8),
@@ -126,6 +131,10 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                         setState(() {
                           _selectedRadius = newValue;
                         });
+                        if (_searchController.text.isNotEmpty) {
+                          widget.onSearch
+                              ?.call(_searchController.text, newValue);
+                        }
                       }
                     },
                   ),
@@ -171,7 +180,8 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                     if (result != null) {
                       widget.onChainsUpdated(result);
                       if (_searchController.text.isNotEmpty) {
-                        widget.onSearch?.call(_searchController.text);
+                        widget.onSearch
+                            ?.call(_searchController.text, _selectedRadius);
                       }
                     }
                   },


### PR DESCRIPTION
## 概要
カラオケ店の検索時に、検索範囲（距離）を指定できる機能を実装しました。

## 実装内容
- 検索フォームの横に距離選択のプルダウンを追加（300m、500m、1000m、2000m）
- デフォルトで500mを選択
- 距離変更時に自動的に再検索を実行
- 選択された距離範囲内のカラオケ店のみを表示

## 変更点
- `SearchHeaderWidget`: 距離選択UIの実装と距離変更時の再検索処理
- `HomeScreen`: 検索処理に距離パラメータを追加
- `PlacesService`: 距離に基づくフィルタリング処理の実装

## 動作確認項目
- [ ] デフォルトで500mが選択されていること
- [ ] 距離を変更すると自動的に再検索されること
- [ ] 選択した距離範囲内の店舗のみが表示されること
- [ ] 現在地からの検索、駅からの検索、エリアからの検索それぞれで正しく動作すること