### PR TITLE
JOYSOUNDカラースキームの適用とデザイン改善

### DIFF
--- a/lib/home/screens/karaoke_chain_settings_screen.dart
+++ b/lib/home/screens/karaoke_chain_settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import '../../theme/app_theme.dart';
 
 class KaraokeChainSettingsScreen extends StatefulWidget {
   final Map<String, bool> initialSelectedChains;
@@ -45,7 +46,7 @@ class _KaraokeChainSettingsScreenState
               child: const Text('保存', style: TextStyle(color: Colors.white)),
             ),
         ],
-        backgroundColor: const Color(0xFF00AEEF),
+        backgroundColor: AppTheme.primaryBlue,
       ),
       body: Column(
         children: [
@@ -54,7 +55,7 @@ class _KaraokeChainSettingsScreenState
             child: Text(
               '※ 上から$_maxVisibleOnHome件までがホーム画面に表示されます',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: const Color(0xFF1A1A1A),
+                    color: AppTheme.textPrimary,
                   ),
             ),
           ),
@@ -91,14 +92,14 @@ class _KaraokeChainSettingsScreenState
                               vertical: 2,
                             ),
                             decoration: BoxDecoration(
-                              color: const Color(0xFF00AEEF).withOpacity(0.2),
+                              color: AppTheme.primaryBlue.withOpacity(0.2),
                               borderRadius: BorderRadius.circular(4),
                             ),
-                            child: const Text(
+                            child: Text(
                               'ホーム表示',
                               style: TextStyle(
                                 fontSize: 12,
-                                color: Color(0xFF00AEEF),
+                                color: AppTheme.primaryBlue,
                               ),
                             ),
                           ),
@@ -107,7 +108,7 @@ class _KaraokeChainSettingsScreenState
                   ),
                   trailing: Checkbox(
                     value: chain.value,
-                    activeColor: const Color(0xFF00AEEF),
+                    activeColor: AppTheme.primaryBlue,
                     onChanged: (bool? value) {
                       if (value != null) {
                         setState(() {

--- a/lib/home/screens/karaoke_chain_settings_screen.dart
+++ b/lib/home/screens/karaoke_chain_settings_screen.dart
@@ -39,10 +39,10 @@ class _KaraokeChainSettingsScreenState
                     Map.fromEntries(_chainSettings);
                 Navigator.pop(context, result);
               },
-              child: const Text('保存', style: TextStyle(color: Colors.white)),
               style: TextButton.styleFrom(
                 foregroundColor: Colors.white,
               ),
+              child: const Text('保存', style: TextStyle(color: Colors.white)),
             ),
         ],
         backgroundColor: const Color(0xFF00AEEF),

--- a/lib/home/screens/karaoke_chain_settings_screen.dart
+++ b/lib/home/screens/karaoke_chain_settings_screen.dart
@@ -30,7 +30,7 @@ class _KaraokeChainSettingsScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('カラオケチェーン設定'),
+        title: const Text('カラオケチェーン設定', style: TextStyle(color: Colors.white)),
         actions: [
           if (_hasChanges)
             TextButton(
@@ -39,9 +39,13 @@ class _KaraokeChainSettingsScreenState
                     Map.fromEntries(_chainSettings);
                 Navigator.pop(context, result);
               },
-              child: const Text('保存'),
+              child: const Text('保存', style: TextStyle(color: Colors.white)),
+              style: TextButton.styleFrom(
+                foregroundColor: Colors.white,
+              ),
             ),
         ],
+        backgroundColor: const Color(0xFF00AEEF),
       ),
       body: Column(
         children: [
@@ -50,7 +54,7 @@ class _KaraokeChainSettingsScreenState
             child: Text(
               '※ 上から$_maxVisibleOnHome件までがホーム画面に表示されます',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Colors.grey[600],
+                    color: const Color(0xFF1A1A1A),
                   ),
             ),
           ),
@@ -87,14 +91,14 @@ class _KaraokeChainSettingsScreenState
                               vertical: 2,
                             ),
                             decoration: BoxDecoration(
-                              color: Colors.blue[100],
+                              color: const Color(0xFF00AEEF).withOpacity(0.2),
                               borderRadius: BorderRadius.circular(4),
                             ),
                             child: const Text(
                               'ホーム表示',
                               style: TextStyle(
                                 fontSize: 12,
-                                color: Colors.blue,
+                                color: Color(0xFF00AEEF),
                               ),
                             ),
                           ),
@@ -103,6 +107,7 @@ class _KaraokeChainSettingsScreenState
                   ),
                   trailing: Checkbox(
                     value: chain.value,
+                    activeColor: const Color(0xFF00AEEF),
                     onChanged: (bool? value) {
                       if (value != null) {
                         setState(() {

--- a/lib/home/screens/karaoke_chain_settings_screen.dart
+++ b/lib/home/screens/karaoke_chain_settings_screen.dart
@@ -95,7 +95,7 @@ class _KaraokeChainSettingsScreenState
                               color: AppTheme.primaryBlue.withOpacity(0.2),
                               borderRadius: BorderRadius.circular(4),
                             ),
-                            child: Text(
+                            child: const Text(
                               'ホーム表示',
                               style: TextStyle(
                                 fontSize: 12,

--- a/lib/home/screens/search_detail_screen.dart
+++ b/lib/home/screens/search_detail_screen.dart
@@ -116,25 +116,16 @@ class _SearchDetailScreenState extends State<SearchDetailScreen> {
           decoration: const InputDecoration(
             hintText: 'カラオケ店を検索',
             border: InputBorder.none,
-            hintStyle: TextStyle(color: Colors.grey),
+            hintStyle: TextStyle(color: Colors.white),
           ),
-          style: Theme.of(context).textTheme.titleLarge,
+          style: const TextStyle(color: Colors.white, fontSize: 18),
           onChanged: _onSearchChanged,
-          onSubmitted: (value) async {
-            if (value.isNotEmpty) {
-              if (!mounted) return;
-              final navigator = Navigator.of(context);
-              final searchType = value.contains('駅') ? 'station' : 'location';
-              await _saveSearchHistory(value, searchType);
-              if (!mounted) return;
-              navigator.pop(value);
-            }
-          },
         ),
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
+          icon: const Icon(Icons.arrow_back, color: Colors.white),
           onPressed: () => Navigator.pop(context),
         ),
+        backgroundColor: const Color(0xFF00AEEF),
       ),
       body: _isSearching
           ? const Center(child: CircularProgressIndicator())

--- a/lib/home/screens/search_detail_screen.dart
+++ b/lib/home/screens/search_detail_screen.dart
@@ -118,7 +118,7 @@ class _SearchDetailScreenState extends State<SearchDetailScreen> {
             child: Row(
               children: [
                 IconButton(
-                  icon: Icon(Icons.arrow_back, color: AppTheme.primaryBlue),
+                  icon: const Icon(Icons.arrow_back, color: AppTheme.primaryBlue),
                   onPressed: () => Navigator.pop(context),
                 ),
                 Expanded(
@@ -149,7 +149,7 @@ class _SearchDetailScreenState extends State<SearchDetailScreen> {
                 ),
                 if (_searchController.text.isNotEmpty)
                   IconButton(
-                    icon: Icon(Icons.clear, color: AppTheme.primaryBlue),
+                    icon: const Icon(Icons.clear, color: AppTheme.primaryBlue),
                     onPressed: () {
                       setState(() {
                         _searchController.clear();
@@ -167,7 +167,7 @@ class _SearchDetailScreenState extends State<SearchDetailScreen> {
       body: Column(
         children: [
           _isSearching
-              ? LinearProgressIndicator(
+              ? const LinearProgressIndicator(
                   backgroundColor: Colors.white,
                   valueColor:
                       AlwaysStoppedAnimation<Color>(AppTheme.primaryBlue),

--- a/lib/home/screens/search_detail_screen.dart
+++ b/lib/home/screens/search_detail_screen.dart
@@ -4,6 +4,7 @@ import '../../models/place_result.dart';
 import '../../services/places_service.dart';
 import '../../services/search_history_service.dart';
 import '../../models/search_history.dart';
+import '../../theme/app_theme.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class SearchDetailScreen extends StatefulWidget {
@@ -117,7 +118,7 @@ class _SearchDetailScreenState extends State<SearchDetailScreen> {
             child: Row(
               children: [
                 IconButton(
-                  icon: const Icon(Icons.arrow_back, color: Color(0xFF00AEEF)),
+                  icon: Icon(Icons.arrow_back, color: AppTheme.primaryBlue),
                   onPressed: () => Navigator.pop(context),
                 ),
                 Expanded(
@@ -141,14 +142,14 @@ class _SearchDetailScreenState extends State<SearchDetailScreen> {
                             vertical: 9, horizontal: 16),
                       ),
                       style: const TextStyle(
-                          color: Color(0xFF1A1A1A), fontSize: 16),
+                          color: AppTheme.textPrimary, fontSize: 16),
                       onChanged: _onSearchChanged,
                     ),
                   ),
                 ),
                 if (_searchController.text.isNotEmpty)
                   IconButton(
-                    icon: const Icon(Icons.clear, color: Color(0xFF00AEEF)),
+                    icon: Icon(Icons.clear, color: AppTheme.primaryBlue),
                     onPressed: () {
                       setState(() {
                         _searchController.clear();
@@ -166,9 +167,10 @@ class _SearchDetailScreenState extends State<SearchDetailScreen> {
       body: Column(
         children: [
           _isSearching
-              ? const LinearProgressIndicator(
+              ? LinearProgressIndicator(
                   backgroundColor: Colors.white,
-                  valueColor: AlwaysStoppedAnimation<Color>(Color(0xFF00AEEF)),
+                  valueColor:
+                      AlwaysStoppedAnimation<Color>(AppTheme.primaryBlue),
                 )
               : const SizedBox(height: 2),
           Expanded(

--- a/lib/home/widgets/bottom_navigation_widget.dart
+++ b/lib/home/widgets/bottom_navigation_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../theme/app_theme.dart';
 
 class BottomNavigationWidget extends StatelessWidget {
   final int selectedIndex;
@@ -29,7 +30,7 @@ class BottomNavigationWidget extends StatelessWidget {
       ],
       currentIndex: selectedIndex,
       onTap: onTap,
-      selectedItemColor: const Color(0xFF00AEEF),
+      selectedItemColor: AppTheme.primaryBlue,
       unselectedItemColor: Colors.grey,
       backgroundColor: Colors.white,
       elevation: 8,

--- a/lib/home/widgets/bottom_navigation_widget.dart
+++ b/lib/home/widgets/bottom_navigation_widget.dart
@@ -29,10 +29,11 @@ class BottomNavigationWidget extends StatelessWidget {
       ],
       currentIndex: selectedIndex,
       onTap: onTap,
-      selectedItemColor: Colors.white,
-      unselectedItemColor: Colors.white70,
-      backgroundColor: const Color(0xFF00AEEF),
-      elevation: 0,
+      selectedItemColor: const Color(0xFF00AEEF),
+      unselectedItemColor: Colors.grey,
+      backgroundColor: Colors.white,
+      elevation: 8,
+      type: BottomNavigationBarType.fixed,
     );
   }
 }

--- a/lib/home/widgets/bottom_navigation_widget.dart
+++ b/lib/home/widgets/bottom_navigation_widget.dart
@@ -29,6 +29,10 @@ class BottomNavigationWidget extends StatelessWidget {
       ],
       currentIndex: selectedIndex,
       onTap: onTap,
+      selectedItemColor: Colors.white,
+      unselectedItemColor: Colors.white70,
+      backgroundColor: const Color(0xFF00AEEF),
+      elevation: 0,
     );
   }
-} 
+}

--- a/lib/home/widgets/search_header_widget.dart
+++ b/lib/home/widgets/search_header_widget.dart
@@ -96,13 +96,30 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                     },
                     decoration: InputDecoration(
                       hintText: 'カラオケ店を検索',
-                      prefixIcon: const Icon(Icons.search),
+                      hintStyle: const TextStyle(
+                          color: Color(0xFF1A1A1A), fontSize: 14),
+                      prefixIcon:
+                          const Icon(Icons.search, color: Color(0xFF00AEEF)),
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(8),
+                        borderSide: BorderSide.none,
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: const BorderSide(
+                            color: Color(0xFF00AEEF), width: 2),
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: const BorderSide(color: Color(0xFFE0E0E0)),
                       ),
                       filled: true,
-                      fillColor: Colors.grey[200],
+                      fillColor: Colors.white,
+                      contentPadding: const EdgeInsets.symmetric(
+                          vertical: 12, horizontal: 16),
                     ),
+                    style:
+                        const TextStyle(color: Color(0xFF1A1A1A), fontSize: 14),
                     onSubmitted: (value) {
                       if (value.isNotEmpty) {
                         widget.onSearch?.call(value, _selectedRadius);
@@ -113,17 +130,28 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                 const SizedBox(width: 8),
                 Container(
                   decoration: BoxDecoration(
-                    color: Colors.grey[200],
+                    color: Colors.white,
                     borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: const Color(0xFF00AEEF)),
                   ),
-                  padding: const EdgeInsets.symmetric(horizontal: 8),
                   child: DropdownButton<String>(
                     value: _selectedRadius,
                     underline: Container(),
+                    icon: const Icon(Icons.arrow_drop_down,
+                        color: Color(0xFF00AEEF)),
+                    dropdownColor: Colors.white,
+                    borderRadius: BorderRadius.circular(8),
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
                     items: _radiusOptions.map((String value) {
                       return DropdownMenuItem<String>(
                         value: value,
-                        child: Text('${value}m'),
+                        child: Text(
+                          '${value}m',
+                          style: const TextStyle(
+                            color: Color(0xFF1A1A1A),
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
                       );
                     }).toList(),
                     onChanged: (String? newValue) {
@@ -141,7 +169,7 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                 ),
               ],
             ),
-            const SizedBox(height: 8),
+            const SizedBox(height: 12),
             Row(
               children: [
                 Expanded(
@@ -152,8 +180,30 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                         return Padding(
                           padding: const EdgeInsets.only(right: 8),
                           child: FilterChip(
-                            label: Text(entry.key),
+                            label: Text(
+                              entry.key,
+                              style: TextStyle(
+                                color: entry.value
+                                    ? Colors.white
+                                    : const Color(0xFF1A1A1A),
+                                fontWeight: entry.value
+                                    ? FontWeight.bold
+                                    : FontWeight.normal,
+                              ),
+                            ),
                             selected: entry.value,
+                            showCheckmark: false,
+                            selectedColor: const Color(0xFF00AEEF),
+                            backgroundColor: Colors.white,
+                            shape: StadiumBorder(
+                              side: BorderSide(
+                                color: entry.value
+                                    ? const Color(0xFF00AEEF)
+                                    : const Color(0xFFE0E0E0),
+                              ),
+                            ),
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 4, vertical: 4),
                             onSelected: (bool selected) {
                               final newChains =
                                   Map<String, bool>.from(widget.selectedChains);
@@ -166,26 +216,38 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                     ),
                   ),
                 ),
-                TextButton(
-                  onPressed: () async {
-                    final result = await Navigator.push<Map<String, bool>>(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => KaraokeChainSettingsScreen(
-                          initialSelectedChains: widget.selectedChains,
+                Container(
+                  child: TextButton.icon(
+                    onPressed: () async {
+                      final result = await Navigator.push<Map<String, bool>>(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => KaraokeChainSettingsScreen(
+                            initialSelectedChains: widget.selectedChains,
+                          ),
                         ),
-                      ),
-                    );
+                      );
 
-                    if (result != null) {
-                      widget.onChainsUpdated(result);
-                      if (_searchController.text.isNotEmpty) {
-                        widget.onSearch
-                            ?.call(_searchController.text, _selectedRadius);
+                      if (result != null) {
+                        widget.onChainsUpdated(result);
+                        if (_searchController.text.isNotEmpty) {
+                          widget.onSearch
+                              ?.call(_searchController.text, _selectedRadius);
+                        }
                       }
-                    }
-                  },
-                  child: const Text('すべて表示'),
+                    },
+                    icon: const Icon(Icons.tune,
+                        size: 18, color: Color(0xFF1A1A1A)),
+                    label: const Text('カスタマイズ',
+                        style: TextStyle(
+                            color: Color(0xFF1A1A1A),
+                            fontWeight: FontWeight.bold,
+                            fontSize: 13)),
+                    style: TextButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 8),
+                    ),
+                  ),
                 ),
               ],
             ),

--- a/lib/home/widgets/search_header_widget.dart
+++ b/lib/home/widgets/search_header_widget.dart
@@ -98,21 +98,24 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                     decoration: InputDecoration(
                       hintText: 'カラオケ店を検索',
                       hintStyle: const TextStyle(
-                          color: AppTheme.textPrimary, fontSize: 14),
+                          color: Color.fromARGB(255, 100, 100, 100), fontSize: 14),
                       prefixIcon:
-                          Icon(Icons.search, color: AppTheme.primaryBlue),
+                          const Icon(Icons.search, color: AppTheme.primaryBlue),
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(8),
-                        borderSide: BorderSide.none,
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(8),
-                        borderSide:
-                            BorderSide(color: AppTheme.primaryBlue, width: 2),
+                        borderSide: const BorderSide(color: AppTheme.primaryBlue, width: 1),
                       ),
                       enabledBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(8),
-                        borderSide: BorderSide(color: AppTheme.divider),
+                        borderSide: const BorderSide(color: AppTheme.primaryBlue, width: 1),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: const BorderSide(color: AppTheme.primaryBlue, width: 1),
+                      ),
+                      disabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: const BorderSide(color: AppTheme.primaryBlue, width: 1),
                       ),
                       filled: true,
                       fillColor: Colors.white,

--- a/lib/home/widgets/search_header_widget.dart
+++ b/lib/home/widgets/search_header_widget.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../screens/karaoke_chain_settings_screen.dart';
 import '../screens/search_detail_screen.dart';
 import '../../app_state.dart';
+import '../../theme/app_theme.dart';
 
 class SearchHeaderWidget extends StatefulWidget {
   final TextEditingController? searchController;
@@ -97,26 +98,29 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                     decoration: InputDecoration(
                       hintText: 'カラオケ店を検索',
                       hintStyle: const TextStyle(
-                          color: Color(0xFF757575), fontSize: 14),
+                          color: AppTheme.textPrimary, fontSize: 14),
                       prefixIcon:
-                          const Icon(Icons.search, color: Color(0xFF00AEEF)),
+                          Icon(Icons.search, color: AppTheme.primaryBlue),
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(8),
-                        borderSide: const BorderSide(
-                            color: Color(0xFF00AEEF), width: 2),
+                        borderSide: BorderSide.none,
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide:
+                            BorderSide(color: AppTheme.primaryBlue, width: 2),
                       ),
                       enabledBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(8),
-                        borderSide: const BorderSide(
-                            color: Color(0xFF00AEEF), width: 1),
+                        borderSide: BorderSide(color: AppTheme.divider),
                       ),
                       filled: true,
                       fillColor: Colors.white,
                       contentPadding: const EdgeInsets.symmetric(
                           vertical: 12, horizontal: 16),
                     ),
-                    style:
-                        const TextStyle(color: Color(0xFF1A1A1A), fontSize: 14),
+                    style: const TextStyle(
+                        color: AppTheme.textPrimary, fontSize: 14),
                     onSubmitted: (value) {
                       if (value.isNotEmpty) {
                         widget.onSearch?.call(value, _selectedRadius);

--- a/lib/home/widgets/search_header_widget.dart
+++ b/lib/home/widgets/search_header_widget.dart
@@ -97,21 +97,18 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                     decoration: InputDecoration(
                       hintText: 'カラオケ店を検索',
                       hintStyle: const TextStyle(
-                          color: Color(0xFF1A1A1A), fontSize: 14),
+                          color: Color(0xFF757575), fontSize: 14),
                       prefixIcon:
                           const Icon(Icons.search, color: Color(0xFF00AEEF)),
                       border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(8),
-                        borderSide: BorderSide.none,
-                      ),
-                      focusedBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(8),
                         borderSide: const BorderSide(
                             color: Color(0xFF00AEEF), width: 2),
                       ),
                       enabledBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(8),
-                        borderSide: const BorderSide(color: Color(0xFFE0E0E0)),
+                        borderSide: const BorderSide(
+                            color: Color(0xFF00AEEF), width: 1),
                       ),
                       filled: true,
                       fillColor: Colors.white,
@@ -217,7 +214,7 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                   ),
                 ),
                 Container(
-                  child: TextButton.icon(
+                  child: IconButton(
                     onPressed: () async {
                       final result = await Navigator.push<Map<String, bool>>(
                         context,
@@ -238,15 +235,6 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                     },
                     icon: const Icon(Icons.tune,
                         size: 18, color: Color(0xFF1A1A1A)),
-                    label: const Text('カスタマイズ',
-                        style: TextStyle(
-                            color: Color(0xFF1A1A1A),
-                            fontWeight: FontWeight.bold,
-                            fontSize: 13)),
-                    style: TextButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 8),
-                    ),
                   ),
                 ),
               ],

--- a/lib/home/widgets/search_header_widget.dart
+++ b/lib/home/widgets/search_header_widget.dart
@@ -213,29 +213,27 @@ class _SearchHeaderWidgetState extends State<SearchHeaderWidget> {
                     ),
                   ),
                 ),
-                Container(
-                  child: IconButton(
-                    onPressed: () async {
-                      final result = await Navigator.push<Map<String, bool>>(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => KaraokeChainSettingsScreen(
-                            initialSelectedChains: widget.selectedChains,
-                          ),
+                IconButton(
+                  onPressed: () async {
+                    final result = await Navigator.push<Map<String, bool>>(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => KaraokeChainSettingsScreen(
+                          initialSelectedChains: widget.selectedChains,
                         ),
-                      );
+                      ),
+                    );
 
-                      if (result != null) {
-                        widget.onChainsUpdated(result);
-                        if (_searchController.text.isNotEmpty) {
-                          widget.onSearch
-                              ?.call(_searchController.text, _selectedRadius);
-                        }
+                    if (result != null) {
+                      widget.onChainsUpdated(result);
+                      if (_searchController.text.isNotEmpty) {
+                        widget.onSearch
+                            ?.call(_searchController.text, _selectedRadius);
                       }
-                    },
-                    icon: const Icon(Icons.tune,
-                        size: 18, color: Color(0xFF1A1A1A)),
-                  ),
+                    }
+                  },
+                  icon: const Icon(Icons.tune,
+                      size: 18, color: Color(0xFF1A1A1A)),
                 ),
               ],
             ),

--- a/lib/home/widgets/search_result_modal_widget.dart
+++ b/lib/home/widgets/search_result_modal_widget.dart
@@ -3,6 +3,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:share_plus/share_plus.dart';
 import '../../models/place_result.dart';
 import '../../services/places_service.dart';
+import '../../theme/app_theme.dart';
 
 class SearchResultModalWidget extends StatefulWidget {
   final ScrollController scrollController;
@@ -69,131 +70,62 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // 店名とレビュー情報
+          // カラオケ店の写真が存在する場合のみ表示
+          if (result.photoReference != null)
+            ClipRRect(
+              borderRadius:
+                  const BorderRadius.vertical(top: Radius.circular(12)),
+              child: Image.network(
+                PlacesService().getPhotoUrl(result.photoReference!),
+                height: 160,
+                width: double.infinity,
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) {
+                  return Container(
+                    height: 100,
+                    color: AppTheme.primaryBlue.withOpacity(0.1),
+                    child: const Center(
+                      child: Icon(Icons.image_not_supported),
+                    ),
+                  );
+                },
+              ),
+            ),
+
+          // 基本情報
           Padding(
             padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Expanded(
                       child: Text(
                         result.name,
                         style: const TextStyle(
                           fontSize: 16,
-                          color: Color(0xFF1A1A1A),
+                          color: AppTheme.textPrimary,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
                     ),
-                    if (result.getDistanceText().isNotEmpty)
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 8, vertical: 4),
-                        decoration: BoxDecoration(
-                          color: const Color(0xFF00AEEF).withOpacity(0.1),
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        child: Row(
-                          children: [
-                            const Icon(
-                              Icons.directions_walk,
-                              size: 14,
-                              color: Color(0xFF00AEEF),
-                            ),
-                            const SizedBox(width: 4),
-                            Text(
-                              result.getDistanceText(),
-                              style: const TextStyle(
-                                color: Color(0xFF00AEEF),
-                                fontWeight: FontWeight.bold,
-                                fontSize: 12,
-                              ),
-                            ),
-                          ],
-                        ),
+                    if (result.rating > 0)
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.star,
+                            size: 16,
+                            color: Colors.amber[700],
+                          ),
+                          const SizedBox(width: 4),
+                          Text('${result.rating}'),
+                        ],
                       ),
                   ],
                 ),
                 const SizedBox(height: 8),
-                // レビュー情報
-                Row(
-                  children: [
-                    // 星の表示
-                    Row(
-                      children: List.generate(5, (index) {
-                        return Icon(
-                          index < result.rating.floor()
-                              ? Icons.star
-                              : index < result.rating
-                                  ? Icons.star_half
-                                  : Icons.star_border,
-                          size: 16,
-                          color: const Color(0xFF00AEEF),
-                        );
-                      }),
-                    ),
-                    const SizedBox(width: 4),
-                    // 評価点数
-                    Text(
-                      result.rating.toString(),
-                      style: const TextStyle(
-                        color: Color(0xFF1A1A1A),
-                        fontSize: 14,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    const SizedBox(width: 4),
-                    // レビュー数
-                    Text(
-                      '(${result.userRatingsTotal})',
-                      style: const TextStyle(
-                        color: Color(0xFF1A1A1A),
-                        fontSize: 14,
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
 
-          // 店舗画像
-          if (result.photoReference != null)
-            ClipRRect(
-              borderRadius: const BorderRadius.only(
-                bottomLeft: Radius.circular(4),
-                bottomRight: Radius.circular(4),
-              ),
-              child: Image.network(
-                PlacesService().getPhotoUrl(result.photoReference!),
-                height: 180,
-                width: double.infinity,
-                fit: BoxFit.cover,
-              ),
-            )
-          else
-            ClipRRect(
-              borderRadius: const BorderRadius.only(
-                bottomLeft: Radius.circular(4),
-                bottomRight: Radius.circular(4),
-              ),
-              child: Image.asset(
-                'assets/images/no_image.png',
-                height: 180,
-                width: double.infinity,
-                fit: BoxFit.cover,
-              ),
-            ),
-
-          // 営業時間と住所
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
                 // 営業時間
                 Row(
                   children: [
@@ -204,7 +136,7 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                       size: 16,
                       color: result.isOpenNow == true
                           ? Colors.green
-                          : const Color(0xFFE4002B),
+                          : AppTheme.primaryRed,
                     ),
                     const SizedBox(width: 8),
                     Text(
@@ -212,7 +144,7 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                       style: TextStyle(
                         color: result.isOpenNow == true
                             ? Colors.green
-                            : const Color(0xFFE4002B),
+                            : AppTheme.primaryRed,
                         fontWeight: FontWeight.bold,
                       ),
                     ),
@@ -221,27 +153,28 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                       result.getOpeningHoursText(),
                       style: TextStyle(
                         color: result.isOpenNow == true
-                            ? const Color(0xFF1A1A1A)
-                            : const Color(0xFFE4002B),
+                            ? AppTheme.textPrimary
+                            : AppTheme.primaryRed,
                       ),
                     ),
                   ],
                 ),
-                // 住所
                 const SizedBox(height: 8),
+
+                // 住所
                 Row(
                   children: [
-                    const Icon(
+                    Icon(
                       Icons.location_on,
                       size: 16,
-                      color: Color(0xFF00AEEF),
+                      color: AppTheme.primaryBlue,
                     ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
                         result.address,
                         style: const TextStyle(
-                          color: Color(0xFF1A1A1A),
+                          color: AppTheme.textPrimary,
                           fontSize: 14,
                         ),
                       ),
@@ -265,7 +198,7 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                           color: Colors.white, fontWeight: FontWeight.bold)),
                   onPressed: () => _openInMaps(result),
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFF00AEEF),
+                    backgroundColor: AppTheme.primaryBlue,
                     foregroundColor: Colors.white,
                     elevation: 2,
                     padding: const EdgeInsets.symmetric(
@@ -278,12 +211,12 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                 const SizedBox(width: 8),
                 if (result.website != null)
                   OutlinedButton.icon(
-                    icon: const Icon(Icons.language, color: Color(0xFF00AEEF)),
-                    label: const Text('ウェブサイト',
-                        style: TextStyle(color: Color(0xFF00AEEF))),
+                    icon: Icon(Icons.language, color: AppTheme.primaryBlue),
+                    label: Text('ウェブサイト',
+                        style: TextStyle(color: AppTheme.primaryBlue)),
                     onPressed: () => _launchUrl(result.website!),
                     style: OutlinedButton.styleFrom(
-                      side: const BorderSide(color: Color(0xFF00AEEF)),
+                      side: BorderSide(color: AppTheme.primaryBlue),
                       padding: const EdgeInsets.symmetric(
                           horizontal: 12, vertical: 8),
                       shape: RoundedRectangleBorder(
@@ -293,12 +226,12 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                   ),
                 const SizedBox(width: 8),
                 OutlinedButton.icon(
-                  icon: const Icon(Icons.share, color: Color(0xFF00AEEF)),
-                  label: const Text('共有',
-                      style: TextStyle(color: Color(0xFF00AEEF))),
+                  icon: Icon(Icons.share, color: AppTheme.primaryBlue),
+                  label:
+                      Text('共有', style: TextStyle(color: AppTheme.primaryBlue)),
                   onPressed: () => _sharePlace(result),
                   style: OutlinedButton.styleFrom(
-                    side: const BorderSide(color: Color(0xFF00AEEF)),
+                    side: BorderSide(color: AppTheme.primaryBlue),
                     padding:
                         const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                     shape: RoundedRectangleBorder(
@@ -309,12 +242,12 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                 const SizedBox(width: 8),
                 if (result.phoneNumber != null)
                   OutlinedButton.icon(
-                    icon: const Icon(Icons.phone, color: Color(0xFF00AEEF)),
-                    label: const Text('電話',
-                        style: TextStyle(color: Color(0xFF00AEEF))),
+                    icon: Icon(Icons.phone, color: AppTheme.primaryBlue),
+                    label: Text('電話',
+                        style: TextStyle(color: AppTheme.primaryBlue)),
                     onPressed: () => _callPhone(result.phoneNumber!),
                     style: OutlinedButton.styleFrom(
-                      side: const BorderSide(color: Color(0xFF00AEEF)),
+                      side: BorderSide(color: AppTheme.primaryBlue),
                       padding: const EdgeInsets.symmetric(
                           horizontal: 12, vertical: 8),
                       shape: RoundedRectangleBorder(

--- a/lib/home/widgets/search_result_modal_widget.dart
+++ b/lib/home/widgets/search_result_modal_widget.dart
@@ -164,7 +164,7 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                 // 住所
                 Row(
                   children: [
-                    Icon(
+                    const Icon(
                       Icons.location_on,
                       size: 16,
                       color: AppTheme.primaryBlue,
@@ -211,12 +211,12 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                 const SizedBox(width: 8),
                 if (result.website != null)
                   OutlinedButton.icon(
-                    icon: Icon(Icons.language, color: AppTheme.primaryBlue),
-                    label: Text('ウェブサイト',
+                    icon: const Icon(Icons.language, color: AppTheme.primaryBlue),
+                    label: const Text('ウェブサイト',
                         style: TextStyle(color: AppTheme.primaryBlue)),
                     onPressed: () => _launchUrl(result.website!),
                     style: OutlinedButton.styleFrom(
-                      side: BorderSide(color: AppTheme.primaryBlue),
+                      side: const BorderSide(color: AppTheme.primaryBlue),
                       padding: const EdgeInsets.symmetric(
                           horizontal: 12, vertical: 8),
                       shape: RoundedRectangleBorder(
@@ -226,12 +226,12 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                   ),
                 const SizedBox(width: 8),
                 OutlinedButton.icon(
-                  icon: Icon(Icons.share, color: AppTheme.primaryBlue),
+                  icon: const Icon(Icons.share, color: AppTheme.primaryBlue),
                   label:
-                      Text('共有', style: TextStyle(color: AppTheme.primaryBlue)),
+                      const Text('共有', style: TextStyle(color: AppTheme.primaryBlue)),
                   onPressed: () => _sharePlace(result),
                   style: OutlinedButton.styleFrom(
-                    side: BorderSide(color: AppTheme.primaryBlue),
+                    side: const BorderSide(color: AppTheme.primaryBlue),
                     padding:
                         const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                     shape: RoundedRectangleBorder(
@@ -242,12 +242,12 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                 const SizedBox(width: 8),
                 if (result.phoneNumber != null)
                   OutlinedButton.icon(
-                    icon: Icon(Icons.phone, color: AppTheme.primaryBlue),
-                    label: Text('電話',
+                    icon: const Icon(Icons.phone, color: AppTheme.primaryBlue),
+                    label: const Text('電話',
                         style: TextStyle(color: AppTheme.primaryBlue)),
                     onPressed: () => _callPhone(result.phoneNumber!),
                     style: OutlinedButton.styleFrom(
-                      side: BorderSide(color: AppTheme.primaryBlue),
+                      side: const BorderSide(color: AppTheme.primaryBlue),
                       padding: const EdgeInsets.symmetric(
                           horizontal: 12, vertical: 8),
                       shape: RoundedRectangleBorder(

--- a/lib/home/widgets/search_result_modal_widget.dart
+++ b/lib/home/widgets/search_result_modal_widget.dart
@@ -62,6 +62,10 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
   Widget _buildResultCard(BuildContext context, PlaceResult result) {
     return Card(
       margin: const EdgeInsets.all(8),
+      elevation: 2,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -71,11 +75,49 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  result.name,
-                  style: Theme.of(context).textTheme.titleLarge,
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        result.name,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          color: Color(0xFF1A1A1A),
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    if (result.getDistanceText().isNotEmpty)
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 4),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF00AEEF).withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(
+                              Icons.directions_walk,
+                              size: 14,
+                              color: Color(0xFF00AEEF),
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              result.getDistanceText(),
+                              style: const TextStyle(
+                                color: Color(0xFF00AEEF),
+                                fontWeight: FontWeight.bold,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                  ],
                 ),
-                const SizedBox(height: 4),
+                const SizedBox(height: 8),
                 // レビュー情報
                 Row(
                   children: [
@@ -89,7 +131,7 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                                   ? Icons.star_half
                                   : Icons.star_border,
                           size: 16,
-                          color: Colors.amber,
+                          color: const Color(0xFF00AEEF),
                         );
                       }),
                     ),
@@ -98,8 +140,9 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                     Text(
                       result.rating.toString(),
                       style: const TextStyle(
-                        color: Colors.grey,
+                        color: Color(0xFF1A1A1A),
                         fontSize: 14,
+                        fontWeight: FontWeight.bold,
                       ),
                     ),
                     const SizedBox(width: 4),
@@ -107,46 +150,47 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                     Text(
                       '(${result.userRatingsTotal})',
                       style: const TextStyle(
-                        color: Colors.grey,
+                        color: Color(0xFF1A1A1A),
                         fontSize: 14,
                       ),
                     ),
                   ],
                 ),
-                // 距離表示
-                if (result.getDistanceText().isNotEmpty)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 4),
-                    child: Text(
-                      result.getDistanceText(),
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            color: Colors.grey[600],
-                          ),
-                    ),
-                  ),
               ],
             ),
           ),
 
           // 店舗画像
           if (result.photoReference != null)
-            Image.network(
-              PlacesService().getPhotoUrl(result.photoReference!),
-              height: 200,
-              width: double.infinity,
-              fit: BoxFit.cover,
+            ClipRRect(
+              borderRadius: const BorderRadius.only(
+                bottomLeft: Radius.circular(4),
+                bottomRight: Radius.circular(4),
+              ),
+              child: Image.network(
+                PlacesService().getPhotoUrl(result.photoReference!),
+                height: 180,
+                width: double.infinity,
+                fit: BoxFit.cover,
+              ),
             )
           else
-            Image.asset(
-              'assets/images/no_image.png', // デフォルト画像を追加する必要があります
-              height: 200,
-              width: double.infinity,
-              fit: BoxFit.cover,
+            ClipRRect(
+              borderRadius: const BorderRadius.only(
+                bottomLeft: Radius.circular(4),
+                bottomRight: Radius.circular(4),
+              ),
+              child: Image.asset(
+                'assets/images/no_image.png',
+                height: 180,
+                width: double.infinity,
+                fit: BoxFit.cover,
+              ),
             ),
 
           // 営業時間と住所
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -158,8 +202,9 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                           ? Icons.check_circle
                           : Icons.access_time,
                       size: 16,
-                      color:
-                          result.isOpenNow == true ? Colors.green : Colors.red,
+                      color: result.isOpenNow == true
+                          ? Colors.green
+                          : const Color(0xFFE4002B),
                     ),
                     const SizedBox(width: 8),
                     Text(
@@ -167,33 +212,38 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
                       style: TextStyle(
                         color: result.isOpenNow == true
                             ? Colors.green
-                            : Colors.red,
+                            : const Color(0xFFE4002B),
+                        fontWeight: FontWeight.bold,
                       ),
                     ),
                     const SizedBox(width: 8),
                     Text(
                       result.getOpeningHoursText(),
                       style: TextStyle(
-                        color:
-                            result.isOpenNow == true ? Colors.grey : Colors.red,
+                        color: result.isOpenNow == true
+                            ? const Color(0xFF1A1A1A)
+                            : const Color(0xFFE4002B),
                       ),
                     ),
                   ],
                 ),
                 // 住所
-                const SizedBox(height: 4),
+                const SizedBox(height: 8),
                 Row(
                   children: [
                     const Icon(
                       Icons.location_on,
                       size: 16,
-                      color: Colors.grey,
+                      color: Color(0xFF00AEEF),
                     ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
                         result.address,
-                        style: const TextStyle(color: Colors.grey),
+                        style: const TextStyle(
+                          color: Color(0xFF1A1A1A),
+                          fontSize: 14,
+                        ),
                       ),
                     ),
                   ],
@@ -205,30 +255,72 @@ class _SearchResultModalWidgetState extends State<SearchResultModalWidget> {
           // アクションボタン
           SingleChildScrollView(
             scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: 8),
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
             child: Row(
               children: [
-                TextButton.icon(
-                  icon: const Icon(Icons.directions),
-                  label: const Text('ここにいく'),
+                ElevatedButton.icon(
+                  icon: const Icon(Icons.directions, color: Colors.white),
+                  label: const Text('ここにいく',
+                      style: TextStyle(
+                          color: Colors.white, fontWeight: FontWeight.bold)),
                   onPressed: () => _openInMaps(result),
-                ),
-                if (result.website != null)
-                  TextButton.icon(
-                    icon: const Icon(Icons.language),
-                    label: const Text('ウェブサイト'),
-                    onPressed: () => _launchUrl(result.website!),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF00AEEF),
+                    foregroundColor: Colors.white,
+                    elevation: 2,
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 10),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
                   ),
-                TextButton.icon(
-                  icon: const Icon(Icons.share),
-                  label: const Text('共有'),
-                  onPressed: () => _sharePlace(result),
                 ),
+                const SizedBox(width: 8),
+                if (result.website != null)
+                  OutlinedButton.icon(
+                    icon: const Icon(Icons.language, color: Color(0xFF00AEEF)),
+                    label: const Text('ウェブサイト',
+                        style: TextStyle(color: Color(0xFF00AEEF))),
+                    onPressed: () => _launchUrl(result.website!),
+                    style: OutlinedButton.styleFrom(
+                      side: const BorderSide(color: Color(0xFF00AEEF)),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 8),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                    ),
+                  ),
+                const SizedBox(width: 8),
+                OutlinedButton.icon(
+                  icon: const Icon(Icons.share, color: Color(0xFF00AEEF)),
+                  label: const Text('共有',
+                      style: TextStyle(color: Color(0xFF00AEEF))),
+                  onPressed: () => _sharePlace(result),
+                  style: OutlinedButton.styleFrom(
+                    side: const BorderSide(color: Color(0xFF00AEEF)),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
                 if (result.phoneNumber != null)
-                  TextButton.icon(
-                    icon: const Icon(Icons.phone),
-                    label: const Text('電話'),
+                  OutlinedButton.icon(
+                    icon: const Icon(Icons.phone, color: Color(0xFF00AEEF)),
+                    label: const Text('電話',
+                        style: TextStyle(color: Color(0xFF00AEEF))),
                     onPressed: () => _callPhone(result.phoneNumber!),
+                    style: OutlinedButton.styleFrom(
+                      side: const BorderSide(color: Color(0xFF00AEEF)),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 8),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                    ),
                   ),
               ],
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,10 +31,10 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primaryColor: const Color(0xFF00AEEF),
         primarySwatch: _createMaterialColor(const Color(0xFF00AEEF)),
-        colorScheme: ColorScheme.light(
-          primary: const Color(0xFF00AEEF),
-          secondary: const Color(0xFFE0E0E0),
-          error: const Color(0xFFE4002B),
+        colorScheme: const ColorScheme.light(
+          primary: Color(0xFF00AEEF),
+          secondary: Color(0xFFE0E0E0),
+          error: Color(0xFFE4002B),
         ),
         textTheme: const TextTheme(
           titleLarge: TextStyle(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,11 +29,76 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        primaryColor: const Color(0xFF00AEEF),
+        primarySwatch: _createMaterialColor(const Color(0xFF00AEEF)),
+        colorScheme: ColorScheme.light(
+          primary: const Color(0xFF00AEEF),
+          secondary: const Color(0xFFE0E0E0),
+          error: const Color(0xFFE4002B),
+        ),
+        textTheme: const TextTheme(
+          titleLarge: TextStyle(
+            fontFamily: 'NotoSansJP',
+            fontWeight: FontWeight.w700,
+            color: Color(0xFF1A1A1A),
+          ),
+          titleMedium: TextStyle(
+            fontFamily: 'NotoSansJP',
+            fontWeight: FontWeight.w700,
+            color: Color(0xFF1A1A1A),
+          ),
+          titleSmall: TextStyle(
+            fontFamily: 'NotoSansJP',
+            fontWeight: FontWeight.w700,
+            color: Color(0xFF1A1A1A),
+          ),
+          bodyLarge: TextStyle(color: Color(0xFF1A1A1A)),
+          bodyMedium: TextStyle(color: Color(0xFF1A1A1A)),
+          bodySmall: TextStyle(color: Color(0xFF1A1A1A)),
+        ),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            textStyle: const TextStyle(
+              fontFamily: 'NotoSansJP',
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+        bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+          selectedLabelStyle: TextStyle(
+            fontFamily: 'NotoSansJP',
+            fontWeight: FontWeight.w700,
+          ),
+          unselectedLabelStyle: TextStyle(
+            fontFamily: 'NotoSansJP',
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        scaffoldBackgroundColor: Colors.white,
+        cardColor: const Color(0xFFE0E0E0),
+        dividerColor: const Color(0xFFE0E0E0),
       ),
       home: const AppStartupHandler(),
     );
   }
+}
+
+// プライマリーカラーからマテリアルカラーを生成する関数
+MaterialColor _createMaterialColor(Color color) {
+  List<double> strengths = <double>[.05, .1, .2, .3, .4, .5, .6, .7, .8, .9];
+  Map<int, Color> swatch = {};
+  final int r = color.red, g = color.green, b = color.blue;
+
+  for (var strength in strengths) {
+    final double ds = 0.5 - strength;
+    swatch[(strength * 1000).round()] = Color.fromRGBO(
+      r + ((ds < 0 ? r : (255 - r)) * ds).round(),
+      g + ((ds < 0 ? g : (255 - g)) * ds).round(),
+      b + ((ds < 0 ? b : (255 - b)) * ds).round(),
+      1,
+    );
+  }
+  return MaterialColor(color.value, swatch);
 }
 
 class AppStartupHandler extends StatelessWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'home/home_screen.dart';
 import 'app_state.dart';
 import 'services/database_helper.dart';
+import 'theme/app_theme.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -28,77 +29,10 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      theme: ThemeData(
-        primaryColor: const Color(0xFF00AEEF),
-        primarySwatch: _createMaterialColor(const Color(0xFF00AEEF)),
-        colorScheme: const ColorScheme.light(
-          primary: Color(0xFF00AEEF),
-          secondary: Color(0xFFE0E0E0),
-          error: Color(0xFFE4002B),
-        ),
-        textTheme: const TextTheme(
-          titleLarge: TextStyle(
-            fontFamily: 'NotoSansJP',
-            fontWeight: FontWeight.w700,
-            color: Color(0xFF1A1A1A),
-          ),
-          titleMedium: TextStyle(
-            fontFamily: 'NotoSansJP',
-            fontWeight: FontWeight.w700,
-            color: Color(0xFF1A1A1A),
-          ),
-          titleSmall: TextStyle(
-            fontFamily: 'NotoSansJP',
-            fontWeight: FontWeight.w700,
-            color: Color(0xFF1A1A1A),
-          ),
-          bodyLarge: TextStyle(color: Color(0xFF1A1A1A)),
-          bodyMedium: TextStyle(color: Color(0xFF1A1A1A)),
-          bodySmall: TextStyle(color: Color(0xFF1A1A1A)),
-        ),
-        elevatedButtonTheme: ElevatedButtonThemeData(
-          style: ElevatedButton.styleFrom(
-            textStyle: const TextStyle(
-              fontFamily: 'NotoSansJP',
-              fontWeight: FontWeight.w700,
-            ),
-          ),
-        ),
-        bottomNavigationBarTheme: const BottomNavigationBarThemeData(
-          selectedLabelStyle: TextStyle(
-            fontFamily: 'NotoSansJP',
-            fontWeight: FontWeight.w700,
-          ),
-          unselectedLabelStyle: TextStyle(
-            fontFamily: 'NotoSansJP',
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-        scaffoldBackgroundColor: Colors.white,
-        cardColor: const Color(0xFFE0E0E0),
-        dividerColor: const Color(0xFFE0E0E0),
-      ),
+      theme: AppTheme.theme,
       home: const AppStartupHandler(),
     );
   }
-}
-
-// プライマリーカラーからマテリアルカラーを生成する関数
-MaterialColor _createMaterialColor(Color color) {
-  List<double> strengths = <double>[.05, .1, .2, .3, .4, .5, .6, .7, .8, .9];
-  Map<int, Color> swatch = {};
-  final int r = color.red, g = color.green, b = color.blue;
-
-  for (var strength in strengths) {
-    final double ds = 0.5 - strength;
-    swatch[(strength * 1000).round()] = Color.fromRGBO(
-      r + ((ds < 0 ? r : (255 - r)) * ds).round(),
-      g + ((ds < 0 ? g : (255 - g)) * ds).round(),
-      b + ((ds < 0 ? b : (255 - b)) * ds).round(),
-      1,
-    );
-  }
-  return MaterialColor(color.value, swatch);
 }
 
 class AppStartupHandler extends StatelessWidget {

--- a/lib/services/search_history_service.dart
+++ b/lib/services/search_history_service.dart
@@ -13,7 +13,7 @@ class SearchHistoryService {
 
   // ユーザーの検索履歴を取得（最新順）
   Future<List<SearchHistory>> getUserSearchHistory(int userId,
-      {int limit = 10}) async {
+      {int limit = 20}) async {
     final db = await _db.database;
     final result = await db.query(
       'search_histories',

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+
+/// アプリケーション全体で使用するテーマ定義
+class AppTheme {
+  AppTheme._(); // プライベートコンストラクタ - インスタンス化防止
+
+  // JOYSOUNDブランドカラー
+  static const Color primaryBlue = Color(0xFF00AEEF); // メインの水色
+  static const Color primaryRed = Color(0xFFE4002B); // アクセントの赤色
+
+  // 一般的なカラー
+  static const Color textPrimary = Color(0xFF1A1A1A); // 主要テキスト色
+  static const Color background = Colors.white; // 背景色
+  static const Color cardBackground = Color(0xFFE0E0E0); // カード背景色
+  static const Color divider = Color(0xFFE0E0E0); // 区切り線
+  static const Color iconBackground = Color(0xFFEEEEEE); // アイコン背景色
+
+  // ColorSchemeの拡張
+  static const ColorScheme colorScheme = ColorScheme.light(
+    primary: primaryBlue,
+    secondary: Color(0xFFE0E0E0),
+    error: primaryRed,
+    onPrimary: Colors.white,
+    onSecondary: textPrimary,
+    onError: Colors.white,
+    background: background,
+    surface: background,
+    onBackground: textPrimary,
+    onSurface: textPrimary,
+  );
+
+  // テキストスタイル
+  static const TextTheme textTheme = TextTheme(
+    titleLarge: TextStyle(
+      fontFamily: 'NotoSansJP',
+      fontWeight: FontWeight.w700,
+      color: textPrimary,
+    ),
+    titleMedium: TextStyle(
+      fontFamily: 'NotoSansJP',
+      fontWeight: FontWeight.w700,
+      color: textPrimary,
+    ),
+    titleSmall: TextStyle(
+      fontFamily: 'NotoSansJP',
+      fontWeight: FontWeight.w700,
+      color: textPrimary,
+    ),
+    bodyLarge: TextStyle(color: textPrimary),
+    bodyMedium: TextStyle(color: textPrimary),
+    bodySmall: TextStyle(color: textPrimary),
+  );
+
+  // ボタンテーマ
+  static final ElevatedButtonThemeData elevatedButtonTheme =
+      ElevatedButtonThemeData(
+    style: ElevatedButton.styleFrom(
+      backgroundColor: primaryBlue,
+      foregroundColor: Colors.white,
+      textStyle: const TextStyle(
+        fontFamily: 'NotoSansJP',
+        fontWeight: FontWeight.w700,
+      ),
+    ),
+  );
+
+  // アウトラインボタンテーマ
+  static final OutlinedButtonThemeData outlinedButtonTheme =
+      OutlinedButtonThemeData(
+    style: OutlinedButton.styleFrom(
+      foregroundColor: primaryBlue,
+      side: const BorderSide(color: primaryBlue),
+      textStyle: const TextStyle(
+        fontFamily: 'NotoSansJP',
+        fontWeight: FontWeight.w500,
+      ),
+    ),
+  );
+
+  // ナビゲーションバーテーマ
+  static const BottomNavigationBarThemeData bottomNavigationBarTheme =
+      BottomNavigationBarThemeData(
+    backgroundColor: Colors.white,
+    selectedItemColor: primaryBlue,
+    unselectedItemColor: Colors.grey,
+    elevation: 8,
+    selectedLabelStyle: TextStyle(
+      fontFamily: 'NotoSansJP',
+      fontWeight: FontWeight.w700,
+    ),
+    unselectedLabelStyle: TextStyle(
+      fontFamily: 'NotoSansJP',
+      fontWeight: FontWeight.w700,
+    ),
+  );
+
+  // プライマリーカラーからマテリアルカラーを生成する関数
+  static MaterialColor createMaterialColor(Color color) {
+    List<double> strengths = <double>[.05, .1, .2, .3, .4, .5, .6, .7, .8, .9];
+    Map<int, Color> swatch = {};
+    final int r = color.red, g = color.green, b = color.blue;
+
+    for (var strength in strengths) {
+      final double ds = 0.5 - strength;
+      swatch[(strength * 1000).round()] = Color.fromRGBO(
+        r + ((ds < 0 ? r : (255 - r)) * ds).round(),
+        g + ((ds < 0 ? g : (255 - g)) * ds).round(),
+        b + ((ds < 0 ? b : (255 - b)) * ds).round(),
+        1,
+      );
+    }
+    return MaterialColor(color.value, swatch);
+  }
+
+  // アプリ全体のテーマデータ
+  static ThemeData get theme {
+    return ThemeData(
+      primaryColor: primaryBlue,
+      primarySwatch: createMaterialColor(primaryBlue),
+      colorScheme: colorScheme,
+      textTheme: textTheme,
+      elevatedButtonTheme: elevatedButtonTheme,
+      outlinedButtonTheme: outlinedButtonTheme,
+      bottomNavigationBarTheme: bottomNavigationBarTheme,
+      scaffoldBackgroundColor: background,
+      cardColor: cardBackground,
+      dividerColor: divider,
+    );
+  }
+}

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -23,9 +23,7 @@ class AppTheme {
     onPrimary: Colors.white,
     onSecondary: textPrimary,
     onError: Colors.white,
-    background: background,
     surface: background,
-    onBackground: textPrimary,
     onSurface: textPrimary,
   );
 


### PR DESCRIPTION
## 変更内容
- JOYSOUNDのロゴカラー(青: #00AEEF、赤: #E4002B)に合わせたUIデザインの変更
- メインのUI要素を水色ベースの白アクセントに統一
- カスタマイズボタンのデザイン改善
- 「ここにいく」ボタンの色を水色に変更
- 店名表示の太字化

## 現在の状態
- デザインの変更は完了していますが、最終確認が必要です